### PR TITLE
Update postgres functions return type and returned data

### DIFF
--- a/tables.sql
+++ b/tables.sql
@@ -22,10 +22,10 @@ values
 
 -- create database function to find nearby stores
 create or replace function nearby_stores(lat float, long float)
-returns setof record
+returns table (id public.stores.id%TYPE, name public.stores.name%TYPE, description public.stores.description%TYPE, lat float, long float, dist_meters float)
 language sql
 as $$
-  select id, name, description, st_astext(location) as location, st_distance(location, st_point(long, lat)::geography) as dist_meters
+  select id, name, description, st_y(location::geometry) as lat, st_x(location::geometry) as long, st_distance(location, st_point(long, lat)::geography) as dist_meters
   from public.stores
   order by location <-> st_point(long, lat)::geography;
 $$;
@@ -33,10 +33,10 @@ $$;
 
 -- create database function to find stores in a specific box
 create or replace function stores_in_view(min_lat float, min_long float, max_lat float, max_long float)
-returns setof record
+returns table (id public.stores.id%TYPE, name public.stores.name%TYPE, lat float, long float)
 language sql
 as $$
-	select id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as long, st_astext(location) as location
+	select id, name, ST_Y(location::geometry) as lat, ST_X(location::geometry) as long
 	from public.stores
 	where location && ST_SetSRID(ST_MakeBox2D(ST_Point(min_long, min_lat), ST_Point(max_long, max_lat)),4326)
 $$;


### PR DESCRIPTION
Hi there, 

Tyler from Supabase here.

When defining postgres functions, returning `setof record` caused some issues with the latest Postgrest. While that is being fixed, we wanted to redirect the users to move away from `setof record` and define the return type. This PR updates the function definition to use table instead of `setof record`. 

Also by looking at the [model definition](https://github.com/saimon24/supabase-postgis-ionic-angular/blob/main/src/app/services/stores.service.ts#L13), it looked like the `nearby_stores` function should return `lat` and `long` instead of `location`, so updated the function definition there. 

The blog article update on supabase.com is included in [this PR](https://github.com/supabase/supabase/pull/16177#pullrequestreview-1560423289), so no need to update on our end!